### PR TITLE
use dirname(@__FILE__) rather than Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ using Compat
 end
 
 @testset "BGZFStream" begin
-    filename = Pkg.dir("BGZFStreams", "test", "bar.bgz")
+    filename = joinpath(dirname(@__FILE__), "bar.bgz")
     stream = BGZFStream(filename, "r")
     @test read(stream, UInt8) === UInt8('b')
     @test read(stream, UInt8) === UInt8('a')


### PR DESCRIPTION
allows installing the package elsewhere