### PR TITLE
do blocks (functions) as argument to BGZFStream

### DIFF
--- a/src/bgzfstream.jl
+++ b/src/bgzfstream.jl
@@ -142,6 +142,20 @@ function BGZFStream(filename::AbstractString, mode::AbstractString="r")
 end
 
 """
+    BGZFStream(f::Function, args....) 
+    Apply the function `f` to the result of `BGZFStream(args...)` and close stream on completion
+"""
+function BGZFStream(f::Function, args...)
+    stream = BGZFStream(args...)
+    try
+        f(stream)
+    finally
+        close(stream)
+    end
+end
+
+
+"""
     virtualoffset(stream::BGZFStream)
 
 Return the current virtual file offset of `stream`.

--- a/src/bgzfstream.jl
+++ b/src/bgzfstream.jl
@@ -134,26 +134,16 @@ function BGZFStream(io::IO, mode::AbstractString="r")
     return BGZFStream(io, mode′, blocks, 1, true, io -> close(io))
 end
 
-function BGZFStream(filename::AbstractString, mode::AbstractString="r")
+function BGZFStream(filename::AbstractString, mode::AbstractString = "r")
     if mode ∉ ("r", "w", "a")
         throw(ArgumentError("invalid mode: '", mode, "'"))
     end
     return BGZFStream(open(filename, mode), mode)
 end
 
-"""
-    BGZFStream(f::Function, args....) 
-    Apply the function `f` to the result of `BGZFStream(args...)` and close stream on completion
-"""
-function BGZFStream(f::Function, args...)
-    stream = BGZFStream(args...)
-    try
-        f(stream)
-    finally
-        close(stream)
-    end
+function Base.open(::Type{BGZFStream}, filepath::AbstractString, mode::AbstractString = "r")
+    return BGZFStream(filepath, mode)
 end
-
 
 """
     virtualoffset(stream::BGZFStream)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,19 +45,19 @@ end
     close(stream)
     @test_throws ArgumentError unsafe_read(stream, pointer(data), 3)
 
-    stream = BGZFStream(filename, "r")
-    @test virtualoffset(stream) === VirtualOffset(0, 0)
-    read(stream, UInt8)
-    read(stream, UInt8)
-    @test virtualoffset(stream) === VirtualOffset(0, 2)
-    seek(stream, VirtualOffset(0, 1))
-    @test read(stream, UInt8) === UInt8('a')
-    @test read(stream, UInt8) === UInt8('r')
-    seekstart(stream)
-    @test read(stream, UInt8) === UInt8('b')
-    @test read(stream, UInt8) === UInt8('a')
-    @test read(stream, UInt8) === UInt8('r')
-    close(stream)
+    BGZFStream(filename, "r") do stream
+        @test virtualoffset(stream) === VirtualOffset(0, 0)
+        read(stream, UInt8)
+        read(stream, UInt8)
+        @test virtualoffset(stream) === VirtualOffset(0, 2)
+        seek(stream, VirtualOffset(0, 1))
+        @test read(stream, UInt8) === UInt8('a')
+        @test read(stream, UInt8) === UInt8('r')
+        seekstart(stream)
+        @test read(stream, UInt8) === UInt8('b')
+        @test read(stream, UInt8) === UInt8('a')
+       @test read(stream, UInt8) === UInt8('r')
+    end
 
     # Empty data.
     empty_block = copy(BGZFStreams.EOF_BLOCK)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
     close(stream)
     @test_throws ArgumentError unsafe_read(stream, pointer(data), 3)
 
-    BGZFStream(filename, "r") do stream
+    open(BGZFStream, filename, "r") do stream
         @test virtualoffset(stream) === VirtualOffset(0, 0)
         read(stream, UInt8)
         read(stream, UInt8)


### PR DESCRIPTION
This adds support for block style usage BGZFStream, e.g., 

BGZFStream(filename, "r") do stream
    ....
end

Code is analogous to that in base  `iostream` https://github.com/JuliaLang/julia/blob/cfac61d88625e3d58b9f0dbd4d9959e640b2a9f0/base/iostream.jl#L149

