### PR TITLE
Avoid BoundsError when determining virtualoffset.

### DIFF
--- a/src/bgzfstream.jl
+++ b/src/bgzfstream.jl
@@ -153,7 +153,7 @@ function virtualoffset(stream::BGZFStream)
     if stream.mode == READ_MODE
         i = ensure_buffered_data(stream)
         if i == 0
-            block = stream.blocks[stream.block_index]
+            block = stream.blocks[end]
         else
             block = stream.blocks[i]
         end


### PR DESCRIPTION
Previously a BoundsError was thrown as `ensure_buffered_data` set the block_index to a too-high value. This value was then used in `virtualoffset` when it shouldn't have been used, causing the error. This commit changes the offending line to use `end` instead of the invalid index.

# A clear and descriptive title (No issue numbers please)

> _This template is rather extensive. Fill out all that you can, if are a new contributor or you're unsure about any section, leave it unchanged and a reviewer will help you_ :smile:. _This template is simply a tool to help everyone remember the BioJulia guidelines, if you feel anything in this template is not relevant, simply delete it._

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have changed current behaviour...
  - Before, using `virtualoffset` could raise a `BoundsError` as the block index could reach an invalid value when near the end of a file.
  - Now `virtualoffset` doesn't raise a `BoundsError` when `ensure_buffered_data` returns 0.

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
