### PR TITLE
Add an eof block check

### DIFF
--- a/src/bgzfstream.jl
+++ b/src/bgzfstream.jl
@@ -317,6 +317,9 @@ end
     @label doit
     while stream.block_index ≤ lastindex(stream.blocks)
         @inbounds block = stream.blocks[stream.block_index]
+        if is_eof_block(block.compressed_block) # Note: `read_blocks!` does not necessarily fill/overwrite blocks till `lastindex(stream.blocks)`, we need to stop incrementing `stream.block_index` when an eof block is encountered.
+            break
+        end
         if block.position ≤ block.size
             return stream.block_index
         end


### PR DESCRIPTION
I think this PR fixes #22, supersedes https://github.com/BioJulia/BGZFStreams.jl/pull/25, and addresses https://github.com/BioJulia/XAM.jl/issues/31.

When using multiple threads, `read_blocks!` will fill `stream.blocks` until it reaches `length(stream.blocks)` or the end of the io stream. This means that the `EOF_BLOCK` can occur anywhere within `stream.blocks` and because of how `stream.blocks` is reused there can be old blocks remaining after the `EOF_BLOCK`.

The current `ensure_buffered_data` function advances `stream.block_index` past the `EOF_Block` because of its `block.size` and `block.positon` and then continues to advance `stream.block_index` to `stream.blocks[end]` due to the previously set `block.position`s.

This PR stops `stream.block_index` from advancing past an encountered `EOF_Block`.