### PR TITLE
Correct `ensure_buffered_data`

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: julia-actions/julia-buildpkg@v1
       - name: Run Tests
         uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: "2"
       - name: Create CodeCov
         uses: julia-actions/julia-processcoverage@v1
       - name: Upload CodeCov

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BGZFStreams"
 uuid = "28d598bf-9b8f-59f1-b38c-5a06b4a0f5e6"
 authors = ["Sabrina Jaye Ward <sabrinajward@protonmail.com>", "Kenta Sato <bicycle1885@gmail.com>", "Daniel C. Jones <dcjones@cs.washington.edu>", "Tony Kelman <tony@kelman.net>", "Elliot Saba <staticfloat@gmail.com>", "Christian Theil Have"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,8 +173,8 @@ end
     @test stream.blocks |> length  == 1 # Note: only one block when writing,
     @test stream.blocks[1].size == BGZFStreams.BGZF_SAFE_BLOCK_SIZE
 
-    # Generate n blocks of data.
-    data = rand(0x00:0xf0, (n*BGZFStreams.BGZF_SAFE_BLOCK_SIZE) )
+    # Generate n+1 blocks of data.
+    data = rand(0x00:0xf0, ((n+1)*BGZFStreams.BGZF_SAFE_BLOCK_SIZE) )
 
     write_offsets = BGZFStreams.VirtualOffset[]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using BGZFStreams
 using Test
 
+@info "Environment" Threads.nthreads()
+
 @testset "VirtualOffset" begin
     voff = VirtualOffset(0, 0)
     @test voff == VirtualOffset(0, 0)


### PR DESCRIPTION
The `read_blocks!` function does not necessarily fill/overwrite blocks till `lastindex(stream.blocks)`, we need to ensure `stream.block_index` does not increment past the index of the last loaded block.